### PR TITLE
Fixes for Python 3.7

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -19,7 +19,7 @@ FOO_SCHEMA = {
 
 # Fixme: Fields in description no longer match
 POINT_SCHEMA = {
-    'description': 'Point(x:float, y:float)',
+    'description': Point.__doc__,
     'type': 'object',
     'properties': {
         'z': {'format': 'float', 'type': 'number'},


### PR DESCRIPTION
This PR fixes 3 issues related to Python 3.7:

* Fixed the detection of Optional types
* Added a method to get type names that works in 3.6 and 3.7
* Handle subtle difference in dataclass docstring between 3.6/3.7