### PR TITLE
Only validate once when parsing nested objects

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -226,7 +226,7 @@ class JsonSchemaMixin:
         for field, field_type in cls._get_type_hints().items():
             if not field.startswith("_"):
                 mapped_field = cls.field_mapping().get(field, field)
-                decoded_data[field] = cls._decode_field(field, field_type, data.get(mapped_field), validate)
+                decoded_data[field] = cls._decode_field(field, field_type, data.get(mapped_field), validate=False)
         return cls(**decoded_data)
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,18 @@ class OpaqueData(JsonSchemaMixin):
     """Structure with unknown types"""
     a: List[Any]
     b: Dict[str, Any]
+
+
+@dataclass
+class Product(JsonSchemaMixin):
+    name: str
+    cost: float
+
+
+@dataclass
+class ShoppingCart(JsonSchemaMixin):
+    items: List[Product]
+
+    @property
+    def cost(self):
+        return sum([item.cost for item in items])


### PR DESCRIPTION
This PR changes the `from_dict` method so that the data is only validated once, instead of for every nested object. This significantly improves performance when parsing large datasets without any change in behaviour. I've added a test that illustrates the nested objects are still validated with this change.