### PR TITLE
Specify dependencies versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 requires = [
-    'python-dateutil',
-    'jsonschema',
-    'dataclasses;python_version<"3.7"'
+    'python-dateutil==2.8.0',
+    'jsonschema==3.0.1',
+    'dataclasses==0.6.0;python_version<"3.7"'
 ]
 
 


### PR DESCRIPTION
For more stability, it would be better to fix the versions of the dependencies in order to keep a stable version even if a foreign library changes.
I took the current latest versions as fixed versions.
Maybe a double equal is too strict ...