### PR TITLE
Field defaults using default_factory are included in generated schema

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -320,8 +320,16 @@ class JsonSchemaMixin:
         default = None
         if isinstance(field, Field):
             field_type = field.type
+            default_value = None
             if field.default is not MISSING and field.default is not None:
-                default = cls._encode_field(field.type, field.default, omit_none=False)
+                # In case of default value given
+                default_value = field.default
+            elif field.default_factory is not MISSING and field.default_factory is not None:
+                # In case of a default factory given, we call it
+                default_value = field.default_factory()
+
+            if default_value is not None:
+                default = cls._encode_field(field.type, default_value, omit_none=False)
                 required = False
         else:
             field_type = field

--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -324,9 +324,9 @@ class JsonSchemaMixin:
             if field.default is not MISSING and field.default is not None:
                 # In case of default value given
                 default_value = field.default
-            elif field.default_factory is not MISSING and field.default_factory is not None:
+            elif field.default_factory is not MISSING and field.default_factory is not None:  # type: ignore
                 # In case of a default factory given, we call it
-                default_value = field.default_factory()
+                default_value = field.default_factory()  # type: ignore
 
             if default_value is not None:
                 default = cls._encode_field(field.type, default_value, omit_none=False)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass, field
+from typing import List
 from uuid import UUID
 
 from .conftest import Foo, Point, Recursive, OpaqueData, ShoppingCart, Product, ProductList, SubSchemas, Bar, Weekday, \
@@ -8,10 +10,10 @@ from dataclasses_jsonschema import SchemaType, ValidationError
 
 try:
     import valico as _
+
     have_valico = True
 except ImportError:
     have_valico = False
-
 
 FOO_SCHEMA = {
     'description': 'A foo that foos',
@@ -28,7 +30,6 @@ FOO_SCHEMA = {
     'type': 'object',
     'required': ['a', 'c', 'd', 'f', 'g']
 }
-
 
 SWAGGER_V2_FOO_SCHEMA = {
     'description': 'A foo that foos',
@@ -142,7 +143,7 @@ ZOO_SCHEMA = {
     'type': 'object',
     'description': "A zoo",
     'properties': {
-        'animal_types': {'additionalProperties': {'type': 'string'}, 'type': 'object'}
+        'animal_types': {'additionalProperties': {'type': 'string'}, 'type': 'object', 'default': {}}
     }
 }
 BAZ_SCHEMA = {
@@ -286,3 +287,15 @@ def test_type_union_deserialise():
 
 def test_default_values():
     assert Product(name="hammer", cost=20.0) == Product.from_dict({"name": "hammer"})
+
+
+def test_default_factory():
+    @dataclass
+    class ClassTest(JsonSchemaMixin):
+        attri: List[str] = field(default_factory=lambda: ['val'])
+
+    assert 'required' not in ClassTest.json_schema().keys()
+
+    assert ClassTest().attri == ['val']
+    assert ClassTest().to_dict() == {'attri': ['val']}
+    assert ClassTest.from_dict({}).attri == ['val']


### PR DESCRIPTION
When a default factory is used, why not writing the default into the json schema ?

Maybe I broke your convention to put the test classes into conf test. Don't hesitate to tell me, I will modify to respect it.