### PR TITLE
Change behavior of typing.Optional (create optional, nullable field)

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -17,10 +17,11 @@ JSON_ENCODABLE_TYPES = {
     str: {'type': 'string'},
     int: {'type': 'integer'},
     bool: {'type': 'boolean'},
-    float: {'type': 'number'}
+    float: {'type': 'number'},
+    type(None): {'type': 'null'},
 }
 
-JsonEncodable = Union[int, float, str, bool]
+JsonEncodable = Union[int, float, str, bool, type(None)]
 JsonDict = Dict[str, Any]
 
 
@@ -40,7 +41,14 @@ def issubclass_safe(klass: Any, base: Type):
 
 
 def is_optional(field: Any) -> bool:
-    return str(field).startswith('typing.Union') and issubclass(field.__args__[1], type(None))
+    if str(field).startswith('typing.Union'):
+        for arg in field.__args__:
+            if isinstance(arg, type) and issubclass(arg, type(None)):
+                return True
+
+    # what about type == Optional[...]?
+
+    return False
 
 
 class FieldEncoder:
@@ -352,6 +360,7 @@ class JsonSchemaMixin:
         if default_value is not None:
             field_meta.default = cls._encode_field(field.type, default_value, omit_none=False)
             required = False
+
         if field.metadata is not None:
             if "description" in field.metadata:
                 field_meta.description = field.metadata["description"]
@@ -360,6 +369,7 @@ class JsonSchemaMixin:
                 if field_meta.read_only and default_value is None:
                     raise ValueError(f"Read-only fields must have a default value")
                 field_meta.write_only = field.metadata.get("write_only")
+
         return field_meta, required
 
     @classmethod
@@ -379,10 +389,13 @@ class JsonSchemaMixin:
         if cls._is_json_schema_subclass(field_type):
             field_schema = {'$ref': '{}/{}'.format(ref_path, field_type_name)}
         else:
-            # If is optional[...]
+            # if Union[..., None]
             if is_optional(field_type):
-                field_schema = cls._get_field_schema(field_type.__args__[0], schema_type)[0]
+                # field_schema = cls._get_field_schema(field_type.__args__[0], schema_type)[0]
                 required = False
+                field_schema = {
+                    'oneOf': [cls._get_field_schema(variant, schema_type)[0] for variant in field_type.__args__]
+                }
             elif is_enum(field_type):
                 member_types = set()
                 values = []

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from .conftest import Foo, Point, Recursive, OpaqueData, ShoppingCart, Product, ProductList, SubSchemas, Bar, Weekday, \
@@ -322,3 +322,13 @@ def test_read_only_field_no_default():
 
     with pytest.raises(ValueError):
         Employee.json_schema(schema_type=SchemaType.OPENAPI_3, embeddable=True)
+
+
+def test_optional_field_no_default():
+    @dataclass
+    class DatabaseModel(JsonSchemaMixin):
+        id: Optional[int]
+
+    schema = DatabaseModel.json_schema(schema_type=SchemaType.OPENAPI_3, embeddable=True)
+
+    assert not hasattr(schema['DatabaseModel'], 'required')

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Union
 from uuid import UUID
 
 from .conftest import Foo, Point, Recursive, OpaqueData, ShoppingCart, Product, ProductList, SubSchemas, Bar, Weekday, \
@@ -19,13 +19,13 @@ FOO_SCHEMA = {
     'description': 'A foo that foos',
     'properties': {
         'a': {'format': 'date-time', 'type': 'string'},
-        'b': {'items': {'$ref': '#/definitions/Point'}, 'type': 'array'},
+        'b': {'oneOf': [{'items': {'$ref': '#/definitions/Point'}, 'type': 'array'}, {'type': 'null'}]},
         'c': {'additionalProperties': {'type': 'integer'}, 'type': 'object'},
         'd': {'type': 'string', 'enum': ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']},
         'f': {'type': 'array', 'minItems': 2, 'maxItems': 2, 'items': [{'type': 'string'}, {'type': 'integer'}]},
         'g': {'type': 'array', 'items': {'type': 'string'}},
-        'e': {'type': 'string', 'minLength': 5, 'maxLength': 8},
-        'h': {'$ref': '#/definitions/Point'}
+        'e': {'oneOf': [{'type': 'string', 'minLength': 5, 'maxLength': 8}, {'type': 'null'}]},
+        'h': {'oneOf': [{'$ref': '#/definitions/Point'}, {'type': 'null'}]},
     },
     'type': 'object',
     'required': ['a', 'c', 'd', 'f', 'g']
@@ -35,7 +35,7 @@ SWAGGER_V2_FOO_SCHEMA = {
     'description': 'A foo that foos',
     'properties': {
         'a': {'format': 'date-time', 'type': 'string'},
-        'b': {'items': {'$ref': '#/definitions/Point'}, 'type': 'array'},
+        'b': {'oneOf': [{'items': {'$ref': '#/definitions/Point'}, 'type': 'array'}, {'type': 'null'}]},
         'c': {'additionalProperties': {'type': 'integer'}, 'type': 'object'},
         'd': {
             'type': 'string',
@@ -44,8 +44,8 @@ SWAGGER_V2_FOO_SCHEMA = {
         },
         'f': {'type': 'array', 'minItems': 2, 'maxItems': 2, 'items': [{'type': 'string'}, {'type': 'integer'}]},
         'g': {'type': 'array', 'items': {'type': 'string'}},
-        'e': {'type': 'string', 'minLength': 5, 'maxLength': 8},
-        'h': {'$ref': '#/definitions/Point'}
+        'e': {'oneOf': [{'type': 'string', 'minLength': 5, 'maxLength': 8}, {'type': 'null'}]},
+        'h': {'oneOf': [{'$ref': '#/definitions/Point'}, {'type': 'null'}]},
     },
     'type': 'object',
     'required': ['a', 'c', 'd', 'f', 'g']
@@ -55,7 +55,7 @@ SWAGGER_V3_FOO_SCHEMA = {
     'description': 'A foo that foos',
     'properties': {
         'a': {'format': 'date-time', 'type': 'string'},
-        'b': {'items': {'$ref': '#/components/schemas/Point'}, 'type': 'array'},
+        'b': {'oneOf': [{'items': {'$ref': '#/components/schemas/Point'}, 'type': 'array'}, {'type': 'null'}]},
         'c': {'additionalProperties': {'type': 'integer'}, 'type': 'object'},
         'd': {
             'type': 'string',
@@ -64,8 +64,8 @@ SWAGGER_V3_FOO_SCHEMA = {
         },
         'f': {'type': 'array', 'minItems': 2, 'maxItems': 2, 'items': [{'type': 'string'}, {'type': 'integer'}]},
         'g': {'type': 'array', 'items': {'type': 'string'}},
-        'e': {'type': 'string', 'minLength': 5, 'maxLength': 8},
-        'h': {'$ref': '#/components/schemas/Point'}
+        'e': {'oneOf': [{'type': 'string', 'minLength': 5, 'maxLength': 8}, {'type': 'null'}]},
+        'h': {'oneOf': [{'$ref': '#/components/schemas/Point'}, {'type': 'null'}]},
     },
     'type': 'object',
     'required': ['a', 'c', 'd', 'f', 'g']
@@ -326,9 +326,19 @@ def test_read_only_field_no_default():
 
 def test_optional_field_no_default():
     @dataclass
-    class DatabaseModel(JsonSchemaMixin):
+    class FooBar(JsonSchemaMixin):
         id: Optional[int]
 
-    schema = DatabaseModel.json_schema(schema_type=SchemaType.OPENAPI_3, embeddable=True)
+    schema = FooBar.json_schema(schema_type=SchemaType.OPENAPI_3, embeddable=True)
 
-    assert not hasattr(schema['DatabaseModel'], 'required')
+    assert not hasattr(schema['FooBar'], 'required')
+
+
+def test_required_union_field_no_default():
+    @dataclass
+    class FooBar(JsonSchemaMixin):
+        id: Union[int]
+
+    schema = FooBar.json_schema(schema_type=SchemaType.OPENAPI_3, embeddable=True)
+
+    assert 'id' in schema['FooBar']['required']


### PR DESCRIPTION
Hi @s-knibbs ,

Thanks for building and maintaining this package. I spent some time evaluating it today and noticed a surprising interaction between typing.Optional and how nullable fields are treated in JSON schema. So, I put together a small proof of concept of what a different approach might look like for discussion.

The thing that specifically surprised me is that according to [the typing.Optional documentation](https://docs.python.org/3/library/typing.html#typing.Optional), Optional is simply an alias for `Union[..., None]`. With defaults, this lets you null a field to indicate a value is not present, or apply a default value. With that in mind, I would expect the following code to work:

```python
from dataclasses import dataclass
from dataclasses_jsonschema import JsonSchemaMixin, SchemaType
from typing import Optional, Union
from pprint import pprint


@dataclass
class DatabaseModel(JsonSchemaMixin):
    """Description"""
    id: Optional[int] = None


print(DatabaseModel.from_dict({}).to_dict()) # works great

print(DatabaseModel.from_dict({'id': None}).to_dict()) # fails
```

The above code fails with:

```
dataclasses_jsonschema.ValidationError: None is not of type 'integer'

Failed validating 'type' in schema['properties']['id']:
    {'type': 'integer'}

On instance['id']:
    None
```

Which is a somewhat surprising way to fail, given that the default value for `id` is `None`!

---

Digging into internals here, it seems like a better way to represent `Optional[int]` is similarly to how you represent `Union[str, int]`, except with `None`/`null` as a first class type. This branch changes the schema generator to use `oneOf: [{type: integer}, {type: null}]` in addition to marking the field as not required. I think this better approximates how I'd expect the JSON schema to look. (although it would be a lot better if there were a way to separately define the field as required vs. nullable, I just don't think typing has a good syntax for that.)

One downside is that this branch in its current state breaks SWAGGER_V2 schema generation. I could modify this to conditionally revert to the old way of generating Optional schemas for SWAGGER_V2. Then this change would only apply to openapi 3 / swagger 3 / json schema.

Let me know what you think & thanks for your time.