### PR TITLE
Implement basic support for literal types

### DIFF
--- a/dataclasses_jsonschema/type_defs.py
+++ b/dataclasses_jsonschema/type_defs.py
@@ -1,4 +1,42 @@
-from typing import Union, Dict, Any
+from enum import Enum
+from typing import Union, Dict, Any, List
+
+try:
+    # Supported in future python versions
+    from typing import TypedDict  # type: ignore
+except ImportError:
+    from mypy_extensions import TypedDict
+
 
 JsonEncodable = Union[int, float, str, bool]
 JsonDict = Dict[str, Any]
+
+
+class JsonSchemaMeta(TypedDict):
+    """JSON schema field definitions. Example usage:
+
+    >>> foo = field(metadata=JsonSchemaMeta(description="A foo that foos"))
+    """
+    description: str
+    title: str
+    examples: List
+    read_only: bool
+    write_only: bool
+    # Additional extension properties that will be output prefixed with 'x-' when generating OpenAPI / Swagger schemas
+    extensions: Dict[str, Any]
+
+
+class SchemaType(Enum):
+    DRAFT_06 = "Draft6"
+    DRAFT_04 = "Draft4"
+    SWAGGER_V2 = "2.0"
+    SWAGGER_V3 = "3.0"
+    # Alias of SWAGGER_V2
+    V2 = "2.0"
+    # Alias of SWAGGER_V3
+    V3 = "3.0"
+    OPENAPI_3 = "3.0"
+
+
+# Retained for backwards compatibility
+SwaggerSpecVersion = SchemaType

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -2,7 +2,7 @@ from _decimal import Decimal
 from dataclasses import dataclass, field
 from ipaddress import IPv4Address, IPv6Address
 from typing import List, NewType
-from typing_extensions import Final
+from typing_extensions import Final, Literal
 from uuid import UUID
 
 from .conftest import Foo, Point, Recursive, OpaqueData, ShoppingCart, Product, ProductList, SubSchemas, Bar, Weekday, \
@@ -436,3 +436,23 @@ def test_final_field():
     assert TestWithFinal.json_schema() == compose_schema(expected_schema)
     assert TestWithFinal.from_dict({'name': 'foo'}) == TestWithFinal(name='foo')
     assert TestWithFinal(name='foo').to_dict() == {'name': 'foo'}
+
+
+def test_literal_types():
+
+    @dataclass
+    class ImageMeta(JsonSchemaMixin):
+        """Image metadata"""
+        bits_per_pixel: Literal[8, 16, 24, "true-color", None]
+
+    expected_schema = {
+        'type': 'object',
+        'description': 'Image metadata',
+        'properties': {
+            'bits_per_pixel': {'enum': [8, 16, 24, 'true-color', None]}
+        },
+        'required': ['bits_per_pixel']
+    }
+    assert ImageMeta.json_schema() == compose_schema(expected_schema)
+    assert ImageMeta(bits_per_pixel=16).to_dict() == {"bits_per_pixel": 16}
+    assert ImageMeta.from_dict({"bits_per_pixel": 16}) == ImageMeta(bits_per_pixel=16)


### PR DESCRIPTION
Fixes #58

**Note**: The following is not currently supported:
* Nested literal types, e.g `Literal[Literal[Literal[1, 2, 3], "foo"], 5, None]` - #65
* Types with enum members, e.g. `Literal[Color.RED]` - #66