### PR TITLE
Add type annotation for declaring nullable types

### DIFF
--- a/dataclasses_jsonschema/type_defs.py
+++ b/dataclasses_jsonschema/type_defs.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, Any, List
+from typing import Union, Dict, Any, List, Type
 
 try:
     # Supported in future python versions
@@ -40,3 +40,25 @@ class SchemaType(Enum):
 
 # Retained for backwards compatibility
 SwaggerSpecVersion = SchemaType
+
+
+class _NULL_TYPE:
+    """Sentinel value to represent null json values for nullable fields, to distinguish them from `None`
+    for omitted fields.
+    """
+    pass
+
+
+NULL = _NULL_TYPE()
+
+
+class _Nullable:
+    """Nullable type annotation. Used to declare fields which can have a null value.
+    This is distinct from `None`, which refers to the absence of a value.
+    """
+
+    def __getitem__(self, item: Type):
+        return Union[item, _NULL_TYPE]
+
+
+Nullable = _Nullable()


### PR DESCRIPTION
Support nullable types in json-schema and openapi 3 schema

Fixes #57