### PR TITLE
Raise error if dataclass inheritance & additional_properties=False both used

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -231,6 +231,8 @@ class JsonSchemaMixin:
                 klass for klass in cls.__bases__ if is_dataclass(klass) and issubclass(klass, JsonSchemaMixin)
             ]
             if len(dataclass_bases) > 0:
+                if not allow_additional_props:
+                    raise TypeError("Dataclass inheritance and additional_props_false=False not currently supported")
                 base_discriminators = [
                     base._discriminator() for base in dataclass_bases if base._discriminator() is not None
                 ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -860,3 +860,16 @@ def test_unrecognized_enum_value():
 
     p = Pet.from_dict({'name': 'snakey', 'type': 'python'}, validate_enums=False)
     assert p.type == "python"
+
+
+def test_inheritance_and_additional_properties_disallowed():
+    @dataclass
+    class Pet(JsonSchemaMixin):
+        name: str
+
+    # Currently this should raise an error until https://github.com/s-knibbs/dataclasses-jsonschema/issues/111
+    # is implemented
+    with pytest.raises(TypeError):
+        @dataclass
+        class Cat(Pet, allow_additional_props=False):
+            hunting_skill: str


### PR DESCRIPTION
See  issue #111 