### PR TITLE
 Allow to use fields for arbitrary schema extensions.

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -162,16 +162,19 @@ class FieldMeta:
     read_only: Optional[bool] = None
     write_only: Optional[bool] = None
     extensions: Optional[Dict[str, Any]] = None
+    schema: Optional[Dict[str, Any]] = None
 
     @property
     def as_dict(self) -> Dict:
         schema_dict = {
             _to_camel_case(k): v
             for k, v in asdict(self).items()
-            if v is not None and k not in ["schema_type", "extensions"]
+            if v is not None and k not in ["schema_type", "extensions", "schema"]
         }
         if (self.schema_type in [SchemaType.SWAGGER_V2, SchemaType.OPENAPI_3]) and self.extensions is not None:
             schema_dict.update({'x-' + k: v for k, v in self.extensions.items()})
+        if self.schema is not None:
+            schema_dict.update(self.schema)
         # Swagger 2 only supports a single example value per property
         if "examples" in schema_dict and len(schema_dict["examples"]) > 0 and self.schema_type == SchemaType.SWAGGER_V2:
             schema_dict["example"] = schema_dict["examples"][0]
@@ -565,6 +568,8 @@ class JsonSchemaMixin:
                 ]
             if "extensions" in field.metadata:
                 field_meta.extensions = field.metadata["extensions"]
+            if "schema" in field.metadata:
+                field_meta.schema = field.metadata["schema"]
             if "description" in field.metadata:
                 field_meta.description = field.metadata["description"]
             if "title" in field.metadata:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,3 +107,10 @@ class ProductList(JsonSchemaMixin):
 class Zoo(JsonSchemaMixin):
     """A zoo"""
     animal_types: Optional[Dict[str, str]] = field(default_factory=dict)
+
+@dataclass
+class Box(JsonSchemaMixin):
+    """A box."""
+    width: int = field(metadata={"schema": {"minimum": 1}})
+    height: int = field(metadata={"schema": {"minimum": 2}})
+    depth: int = field(metadata={"schema": {"minimum": 3}})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -151,6 +151,30 @@ BAZ_SCHEMA = {
     'properties': {'a': {'$ref': '#/definitions/Point', 'default': {'z': 0.0, 'y': 0.0}}},
     'type': 'object'
 }
+BOX_SCHEMA = {
+    'description': 'A box.',
+    'properties': {
+        'depth': {
+            'minimum': 3,
+            'type': 'integer'
+        },
+        'height': {
+            'minimum': 2,
+            'type': 'integer'
+        },
+        'width': {
+            'minimum': 1,
+            'type': 'integer'
+        }
+    },
+    'required': [
+        'width',
+        'height',
+        'depth'
+    ],
+    'type': 'object'
+}
+
 
 
 def compose_schema(schema, definitions=None):
@@ -190,7 +214,8 @@ def test_embeddable_json_schema():
         'ShoppingCart': SHOPPING_CART_SCHEMA,
         'OpaqueData': OPAQUE_DATA_SCHEMA,
         'Zoo': ZOO_SCHEMA,
-        'Baz': BAZ_SCHEMA
+        'Baz': BAZ_SCHEMA,
+        'Box': BOX_SCHEMA,
     }
     assert expected == JsonSchemaMixin.all_json_schemas()
     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION

## What does it do

This adds "schema" into FieldMeta, that is used to add arbitrary updates to schema (similar to extensions, but not adding x-). Alternate option was to make extensions to work without "x-" if it is not swagger, but that didn't look backward compatible.

## Why
https://github.com/s-knibbs/dataclasses-jsonschema/issues/120

Currently, you can use field metadata for custom descriptions, examples. But to do more custom validation (like constraints for integers), you have to use NewType and registering this type. While NewType is good for things like Email, and Enum-like things, it's cumbersome for numeric things, since you have to create newtype for each restriction (i.e. for restricting by 1 and 0 you need separate types). Instead, metadata from field could be used, as like this:
```
@dataclass
class Box(JsonSchemaMixin):
    """A box."""
    width: int = field(metadata={
        "description": "Some description", 
        "schema": {"minimum": 1}
    })
```
