### PR TITLE
Improved behaviour when decoding nullable values that did not come from the encoder

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -400,8 +400,8 @@ class JsonSchemaMixin:
 
     @classmethod
     def _decode_field(cls, field: str, field_type: Any, value: Any) -> Any:
-        if value is None:
-            return NULL if is_nullable(field_type) else None
+        if value is None and is_nullable(field_type):
+            return None
         decoder = None
         try:
             decoder = cls.__decode_cache[field_type]  # type: ignore


### PR DESCRIPTION
If a type is nullable and we got None input, we should decode as None and not the _NULL_TYPE class.

Otherwise it causes strange behaviour