### PR TITLE
No longer require typing-extensions for python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ language: python
 python:
     - "3.6"
     - "3.7"
+    - "3.8"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ Dataclasses JSON Schema
     :target: https://lgtm.com/projects/g/s-knibbs/dataclasses-jsonschema/context:python
     :alt:    Language grade: Python
 
+**Please Note:** This project is in maintenance mode. I'm currently only making urgent bugfixes.
+
 A library to generate JSON Schema from python 3.7 dataclasses. Python 3.6 is supported through the `dataclasses backport <https://github.com/ericvsmith/dataclasses>`_. Aims to be a more lightweight alternative to similar projects such as `marshmallow <https://github.com/marshmallow-code/marshmallow>`_ & `pydantic <https://github.com/samuelcolvin/pydantic>`_.
 
 Feature Overview

--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -13,9 +13,9 @@ from enum import Enum
 import warnings
 
 try:
-    from typing_extensions import Final, Literal
-except ModuleNotFoundError:
-    from typing import Final, Literal
+    from typing import Final, Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Final, Literal  # type: ignore
 
 
 from dataclasses_jsonschema.field_types import (  # noqa: F401

--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -12,7 +12,10 @@ from uuid import UUID
 from enum import Enum
 import warnings
 
-from typing_extensions import Final, Literal
+try:
+    from typing_extensions import Final, Literal
+except ModuleNotFoundError:
+    from typing import Final, Literal
 
 
 from dataclasses_jsonschema.field_types import (  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requires = [
     'python-dateutil',
     'jsonschema',
     'mypy_extensions',
-    'typing_extensions',
+    'typing_extensions;python_version<"3.8"',
     'dataclasses;python_version<"3.7"'
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # TODO: Figure out how to get tox to use setup.py deps
 [tox]
-envlist = py36,py37,{py36,py37}-fastvalidation
+envlist = py36,py37,py38,{py36,py37,py38}-fastvalidation
 
 [testenv]
 commands =


### PR DESCRIPTION
Add python 3.8 to CI

Closes #142