### PR TITLE
Nullable is always Falsey

### DIFF
--- a/dataclasses_jsonschema/type_defs.py
+++ b/dataclasses_jsonschema/type_defs.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Union, Dict, Any, List, TypeVar
+from typing import Union, Dict, Any, List, TypeVar, Literal
 
 try:
     # Supported in future python versions
@@ -47,7 +47,8 @@ class _NULL_TYPE:
     """Sentinel value to represent null json values for nullable fields, to distinguish them from `None`
     for omitted fields.
     """
-    pass
+    def __bool__(self) -> Literal[False]:
+        return False
 
 
 NULL = _NULL_TYPE()

--- a/tests/nullable.py
+++ b/tests/nullable.py
@@ -1,0 +1,20 @@
+"""
+This script is used to test if mypy understands that the Nullable type is always False-y.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+
+from dataclasses_jsonschema.type_defs import Nullable
+
+
+@dataclass
+class Example:
+    name: Nullable[str | None] = None
+
+
+example = Example("sienna")
+
+assert example.name  # If this assert passes we know `name` is a string (because it isn't None or Nullable)
+
+name_upper = example.name.upper()


### PR DESCRIPTION
This PR allows mypy to understand that the `Nullable` type is always false-y, so that mypy finds this valid:

```python
@dataclass
class Example:
    name: Nullable[str | None] = None

example = Example("sienna")

assert example.name  # If this assert passes we know `name` is a string (because it isn't None or Nullable)

name_upper = example.name.upper()
```