### PR TITLE
Add check that literal values are valid to decode_field

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -4,7 +4,7 @@ import sys
 import functools
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
-from typing import Optional, Type, Union, Any, Dict, Tuple, List, Callable, TypeVar
+from typing import Optional, Type, Union, Any, Dict, Tuple, List, Callable, TypeVar, get_args
 import re
 from datetime import datetime, date
 from dataclasses import fields, is_dataclass, Field, MISSING, dataclass, asdict
@@ -416,6 +416,8 @@ class JsonSchemaMixin:
         except (KeyError, TypeError):
             # Note: Only literal types composed of primitive values are currently supported
             if type(value) in JSON_ENCODABLE_TYPES and (field_type in JSON_ENCODABLE_TYPES or is_literal(field_type)):
+                if is_literal(field_type) and value not in get_args(field_type):
+                    raise TypeError('Literal value is not in allowed set of values for type.')
                 return value
             # Replace any nested dictionaries with their targets
             field_type_name = cls._get_field_type_name(field_type)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1002,3 +1002,26 @@ def test_custom_format():
 
     post = Post.from_dict({"content": "Lorem ipsum dolor ...", "slug": "some-post"})
     assert post.slug == Slug("some-post")
+
+
+def test_decode_literal():
+    @dataclass
+    class Foo(JsonSchemaMixin):
+        common_field: int
+        name: Literal['Foo'] = 'Foo'
+
+    @dataclass
+    class Bar(JsonSchemaMixin):
+        common_field: int
+        name: Literal['Bar'] = 'Bar'
+        other_field: Optional[int] = None
+
+    @dataclass
+    class Baz(JsonSchemaMixin):
+        my_foo_bar: Union[Bar, Foo]
+
+    decoded = Baz.from_dict(Baz(my_foo_bar=Foo(common_field=1)).to_dict())
+
+    # Even though Bar comes first in the Union for 'my_foor_bar', the literal check on 'name' should
+    # verify that this is a Foo and not assign it to a Bar
+    assert type(decoded.my_foo_bar) == Foo


### PR DESCRIPTION
Adds an explicit check that a literal field has a valid value when decoding. This will improve decoding when types in a Union have overlapping fields but may be discriminated by a literal.