### PR TITLE
Make type hint of from_json() compatible with json.loads()

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -854,7 +854,7 @@ class JsonSchemaMixin:
             return str(field_type) if match is None else match.group(1)
 
     @classmethod
-    def from_json(cls: Type[T], data: str, validate: bool = True, **json_kwargs) -> T:
+    def from_json(cls: Type[T], data: Union[str, bytes], validate: bool = True, **json_kwargs) -> T:
         return cls.from_dict(json.loads(data, **json_kwargs), validate)
 
     def to_json(self, omit_none: bool = True, validate: bool = False, **json_kwargs) -> str:


### PR DESCRIPTION
The change makes type hint for `data` parameter of `from_json()` compatible with the corresponding one in `json.loads()`.

It makes me trouble during interactions with different libraries, but I hope it can be useful for others.

Of course, it can be solved as `Cls.from_dict(json.loads(x))`, but I appreciate the `from_json` interface.