### PR TITLE
Add python 3.10 to tox and classifier

### DIFF
--- a/dataclasses_jsonschema/__init__.py
+++ b/dataclasses_jsonschema/__init__.py
@@ -380,7 +380,7 @@ class JsonSchemaMixin:
                 members = inspect.getmembers(cls, inspect.isdatadescriptor)
                 for name, member in members:
                     if name != "__weakref__" and (include_properties is None or name in include_properties):
-                        f = Field(MISSING, None, None, None, None, None, None)
+                        f = Field(MISSING, None, None, None, None, None, None, None)
                         f.name = name
                         f.type = member.fget.__annotations__['return']
                         mapped_fields.append(JsonSchemaField(f, name, is_property=True))

--- a/dataclasses_jsonschema/apispec.py
+++ b/dataclasses_jsonschema/apispec.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Optional, Union, Dict
+from typing import Any
 
 try:
     from apispec import BasePlugin, APISpec
@@ -6,7 +6,7 @@ try:
 except ImportError:
     raise ImportError("Missing the 'apispec' package. Try installing with 'dataclasses-jsonschema[apispec]'")
 
-from . import T, SchemaType
+from . import SchemaType
 
 
 def _schema_reference(name: str, schema_type: SchemaType) -> str:
@@ -35,7 +35,8 @@ class DataclassesPlugin(BasePlugin):
     def _schema_type(self) -> SchemaType:
         return SchemaType.SWAGGER_V2 if self.spec.openapi_version.major == 2 else SchemaType.OPENAPI_3
 
-    def schema_helper(self, name: str, _: Any, schema: Optional[Union[Type[T], Dict]] = None, **kwargs):
+    def schema_helper(self, name: str, definition: Any, **kwargs):
+        schema = kwargs.get("schema", None)
         if isinstance(schema, dict) or schema is None:
             return schema
         json_schemas = schema.json_schema(schema_type=self._schema_type, embeddable=True)

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # TODO: Figure out how to get tox to use setup.py deps
 [tox]
-envlist = py36,py37,py38,py39,{py36,py37,py38,py39}-fastvalidation
+envlist = py36,py37,py38,py39,py310{py36,py37,py38,py39,py310}-fastvalidation
 
 [gh-actions]
 python =
@@ -8,6 +8,7 @@ python =
     3.7: py37, py37-fastvalidation
     3.8: py38, py38-fastvalidation
     3.9: py39, py39-fastvalidation
+    3.10: py310, py310-fastvalidation
 
 [testenv]
 commands =


### PR DESCRIPTION
For https://github.com/s-knibbs/dataclasses-jsonschema/issues/181:

### Summary

New in version 3.10: [`dataclasses.field(..., kw_only=MISSING)`](https://docs.python.org/3/library/dataclasses.html#dataclasses.field)

`kw_only`: If true, this field will be marked as keyword-only. This is used when the generated __init__() method’s parameters are computed.

---

```
dataclasses_jsonschema/apispec.py:38: error: Signature of "schema_helper" incompatible with supertype "BasePlugin"
dataclasses_jsonschema/apispec.py:38: note:      Superclass:
dataclasses_jsonschema/apispec.py:38: note:          def schema_helper(self, name: str, definition: Dict[Any, Any], **kwargs: Any) -> Optional[Dict[Any, Any]]
dataclasses_jsonschema/apispec.py:38: note:      Subclass:
dataclasses_jsonschema/apispec.py:38: note:          def [T <: JsonSchemaMixin] schema_helper(self, name: str, _: Any, *, schema: Union[Type[T], Dict[Any, Any], None] = ..., **kwargs: Any) -> Any
```

`schema_helper(self, name: str, _: Any, *, schema: Union[Type[T], Dict[Any, Any], None] = None, **kwargs: Any)`  
→   
`schema_helper(self, name: str, definition: Any, **kwargs)` + `schema = kwargs.get("schema", None)`

### Testing

```bash
$ tox -e py310
GLOB sdist-make: /home/matthew/dataclasses-jsonschema/setup.py
py310 create: /home/matthew/dataclasses-jsonschema/.tox/py310
py310 installdeps: pytest, pytest-ordering, flake8, mypy, apispec[yaml], apispec_webframeworks, flask, types-python-dateutil
py310 inst: /home/matthew/dataclasses-jsonschema/.tox/.tmp/package/1/dataclasses-jsonschema-2.15.2.dev1+g58e3f8c.zip
py310 installed: apispec==5.2.1,apispec-webframeworks==0.5.2,attrs==21.4.0,click==8.1.3,dataclasses-jsonschema @ file:///home/matthew/dataclasses-jsonschema/.tox/.tmp/package/1/dataclasses-jsonschema-2.15.2.dev1%2Bg58e3f8c.zip,flake8==4.0.1,Flask==2.1.2,iniconfig==1.1.1,itsdangerous==2.1.2,Jinja2==3.1.2,jsonschema==4.5.1,MarkupSafe==2.1.1,mccabe==0.6.1,mypy==0.950,mypy-extensions==0.4.3,packaging==21.3,pluggy==1.0.0,py==1.11.0,pycodestyle==2.8.0,pyflakes==2.4.0,pyparsing==3.0.8,pyrsistent==0.18.1,pytest==7.1.2,pytest-ordering==0.6,python-dateutil==2.8.2,PyYAML==6.0,six==1.16.0,tomli==2.0.1,types-python-dateutil==2.8.15,typing_extensions==4.2.0,Werkzeug==2.1.2
py310 run-test-pre: PYTHONHASHSEED='1918695258'
py310 run-test: commands[0] | pytest tests
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
cachedir: .tox/py310/.pytest_cache
rootdir: /home/matthew/dataclasses-jsonschema
plugins: ordering-0.6
collected 47 items                                                                                                                                                                                                                           

tests/test_core.py ............................................                                                                                                                                                                        [ 93%]
tests/test_peps.py ..                                                                                                                                                                                                                  [ 97%]
tests/test_apispec_plugin.py .                                                                                                                                                                                                         [100%]

============================================================================================================== warnings summary ==============================================================================================================
.tox/py310/lib/python3.10/site-packages/apispec/utils.py:104
  /home/matthew/dataclasses-jsonschema/.tox/py310/lib/python3.10/site-packages/apispec/utils.py:104: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    MIN_INCLUSIVE_VERSION = version.LooseVersion("2.0")

.tox/py310/lib/python3.10/site-packages/apispec/utils.py:105
  /home/matthew/dataclasses-jsonschema/.tox/py310/lib/python3.10/site-packages/apispec/utils.py:105: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    MAX_EXCLUSIVE_VERSION = version.LooseVersion("4.0")

.tox/py310/lib/python3.10/site-packages/setuptools/_distutils/version.py:351
.tox/py310/lib/python3.10/site-packages/setuptools/_distutils/version.py:351
  /home/matthew/dataclasses-jsonschema/.tox/py310/lib/python3.10/site-packages/setuptools/_distutils/version.py:351: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)

.tox/py310/lib/python3.10/site-packages/apispec/utils.py:118
  /home/matthew/dataclasses-jsonschema/.tox/py310/lib/python3.10/site-packages/apispec/utils.py:118: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    super().__init__(openapi_version)

tests/test_apispec_plugin.py:144
  /home/matthew/dataclasses-jsonschema/tests/test_apispec_plugin.py:144: PytestUnknownMarkWarning: Unknown pytest.mark.last - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.last

tests/test_core.py::test_any_type_schema
  /home/matthew/dataclasses-jsonschema/dataclasses_jsonschema/__init__.py:732: UserWarning: Unable to create schema for 'Any'
    warnings.warn(f"Unable to create schema for '{field_type_name}'")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================= 47 passed, 7 warnings in 0.22s =======================================================================================================
py310 run-test: commands[1] | flake8 dataclasses_jsonschema
py310 run-test: commands[2] | mypy dataclasses_jsonschema
Success: no issues found in 5 source files
__________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
  py310: commands succeeded
  congratulations :)
```